### PR TITLE
Merge vcf fix for 20k wdl

### DIFF
--- a/20k_Throughput-run/PairedSingleSampleWf_noqc_nocram_optimized.wdl.20k
+++ b/20k_Throughput-run/PairedSingleSampleWf_noqc_nocram_optimized.wdl.20k
@@ -1007,8 +1007,8 @@ task MergeVCFs {
       export GATK_LOCAL_JAR=${tool_path}/gatk-jar && \
       ${tool_path}/gatk/gatk --java-options -Xmx${java_heap_memory_initial} \
       MergeVcfs \
-      --INPUT=${sep=' --INPUT=' input_vcfs} \
-      --OUTPUT=${output_vcf_name}
+      -I ${sep=' --INPUT ' input_vcfs} \
+      -O ${output_vcf_name}
   >>>
   runtime {
     memory: memory


### PR DESCRIPTION
- gatk-jar parse error will be fixed by this change , previous one is compatible for picard input style
**Error:** 
_Can't parse option name containing an embedded '='_ (INPUT=/mnt/genomics/cromwell/cromwell-slurm-exec/PairedEndSingleSampleWorkflow/2e009254-6799-4113-acf2-fd2b9eaca7d1/call-MergeVCFs/inputs/1593445738/NA12878.vcf.gz)